### PR TITLE
fix: align flattened batch handling in qkan

### DIFF
--- a/src/qkan/qkan.py
+++ b/src/qkan/qkan.py
@@ -691,6 +691,7 @@ class QKAN(nn.Module):
             raise NotImplementedError()
 
         x = x.view(-1, T)
+        B_flat = x.shape[0]  # Flattened batch size (e.g., (B,C,T) -> (B*C,T))
         if self.input_id is not None:
             x = x[:, self.input_id.long()]
 
@@ -708,7 +709,8 @@ class QKAN(nn.Module):
         for layer in self.layers:
             if self.save_act and isinstance(layer, QKANLayer):
                 self.subnode_actscale.append(torch.std(x, dim=0).detach())
-                preacts = x[:, None, :].expand(B, layer.out_dim, layer.in_dim)
+                # Use the flattened batch size to match x after view(-1, T)
+                preacts = x[:, None, :].expand(B_flat, layer.out_dim, layer.in_dim)
                 postacts = layer.forward_no_sum(x)  # shape: (batch, out_dim, in_dim)
 
             x = layer(x)

--- a/src/qkan/solver.py
+++ b/src/qkan/solver.py
@@ -125,6 +125,10 @@ def torch_exact_solver(
             preacts_bias = preacts_bias.repeat(repeat_out, repeat_in, 1)[:, :in_dim, :]
         encoded_x = torch.einsum("oir,bi->boir", preacts_weight, x).add(preacts_bias)
         # encoded_x shape: (batch_size, out_dim, in_dim, reps)
+    else:
+        # When pre-activation is not trainable, fall back to using raw x (broadcasted)
+        # so that ansatz implementations (e.g., px_encoding) can always index encoded_x.
+        encoded_x = x[:, None, :, None].expand(batch, out_dim, in_dim, reps)
 
     def _pz_encoding(theta: torch.Tensor):
         """


### PR DESCRIPTION
<img width="1146" height="727" alt="image" src="https://github.com/user-attachments/assets/aee41496-b80d-415f-ba97-f5d38958ab1d" />

<img width="1134" height="778" alt="image" src="https://github.com/user-attachments/assets/44cdb6f3-26bf-46c1-ae1f-4917a5d4a80b" />
