### PR TITLE
perf(flash): optimize large PZ backward launches

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include src/qkan/csrc/*.cu
 include src/qkan/csrc/*.cuh
+include src/qkan/solver/flash/policies/*.json
 include scripts/*.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,9 @@ Homepage = "https://github.com/Jim137/qkan"
 # guard in solver/cute/cute_ops.py JIT-rebuilds from them when the prebuilt
 # kernel does not match the local GPU — including from installed wheels.
 qkan = ["csrc/*.cu"]
+# PZ backward launch policies are read at runtime through importlib.resources,
+# so they must be present in wheels as well as in the source tree.
+"qkan.solver.flash.policies" = ["*.json"]
 
 [tool.ruff]
 lint.select = ["F", "I"]

--- a/skills/tests/test_pz_launch_policy.py
+++ b/skills/tests/test_pz_launch_policy.py
@@ -1,0 +1,744 @@
+# Copyright (c) 2026, Jiun-Cheng Jiang. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only tests for the PZ backward launch-policy loader and selector."""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+import warnings
+from contextlib import contextmanager
+from importlib import import_module, resources
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from qkan._kernel_utils import _select_block_b
+from qkan.solver.flash import launch_policy
+from qkan.solver.flash.launch_policy import (
+    BlockSelectorKind,
+    LaunchConfig,
+    LaunchPolicyMismatchError,
+    LaunchPolicyNotFoundError,
+    LaunchPolicyValidationError,
+    MatchKind,
+    PrecisionKind,
+    load_launch_policy,
+    precision_plan,
+    select_pz_backward_policy,
+    validate_launch_policy_document,
+)
+
+POLICY_N256 = "pz-gfx942-n256-batch4096-r3-fixed-preacts-fast-v1"
+POLICY_N256_B512 = "pz-gfx942-n256-batch512-r3-fixed-preacts-fast-v1"
+POLICY_N10000 = "pz-gfx942-n10000-batch1000-r3-fixed-preacts-fast-v1"
+POLICY_DEFAULT = "default"
+
+
+def policy_document(name: str) -> dict[str, object]:
+    text = (
+        resources.files("qkan.solver.flash.policies")
+        .joinpath(f"{name}.json")
+        .read_text(encoding="utf-8")
+    )
+    return json.loads(text)
+
+
+def select(
+    *,
+    n_oi: int,
+    batch: int,
+    precision: PrecisionKind = PrecisionKind.FP32,
+    architecture: str | None = "gfx942:sramecc+:xnack-",
+    reps: int = 3,
+    preacts_trainable: bool = False,
+    fast_measure: bool = True,
+    policy_name: str | None = None,
+):
+    return select_pz_backward_policy(
+        n_oi=n_oi,
+        batch=batch,
+        architecture=architecture,
+        precision=precision,
+        reps=reps,
+        preacts_trainable=preacts_trainable,
+        fast_measure=fast_measure,
+        policy_name=policy_name,
+    )
+
+
+class PrecisionAndDefaultTests(unittest.TestCase):
+    def test_fp8_plan_preserves_current_contract(self) -> None:
+        fp8 = precision_plan(PrecisionKind.FP8)
+        self.assertEqual(
+            (
+                fp8.kind,
+                fp8.io_dtype_name,
+                fp8.state_dtype_name,
+                fp8.state_itemsize,
+                fp8.fp8_prescale,
+                fp8.launch_precision_key,
+            ),
+            (
+                PrecisionKind.FP8,
+                "bfloat16",
+                "float8_e4m3fn",
+                1,
+                224.0,
+                "fp8",
+            ),
+        )
+
+    def test_none_and_explicit_default_are_identical(self) -> None:
+        for n_oi, batch, architecture in (
+            (256, 4096, None),
+            (10000, 1000, "gfx942:sramecc+:xnack-"),
+            (896, 500, "gfx950"),
+            (1, 33, "sm90"),
+        ):
+            for precision in PrecisionKind:
+                with self.subTest(
+                    n_oi=n_oi,
+                    batch=batch,
+                    architecture=architecture,
+                    precision=precision,
+                ):
+                    omitted = select(
+                        n_oi=n_oi,
+                        batch=batch,
+                        architecture=architecture,
+                        precision=precision,
+                        policy_name=None,
+                    )
+                    explicit = select(
+                        n_oi=n_oi,
+                        batch=batch,
+                        architecture=architecture,
+                        precision=precision,
+                        policy_name=POLICY_DEFAULT,
+                    )
+                    expected_block = _select_block_b(n_oi, batch)
+                    self.assertEqual(omitted, explicit)
+                    self.assertEqual(omitted.policy_name, POLICY_DEFAULT)
+                    self.assertEqual(
+                        omitted.launch,
+                        LaunchConfig(expected_block, 4, 0, 2),
+                    )
+
+    def test_default_never_pads_state_beyond_the_original_selector(self) -> None:
+        """The default policy must not grow the padded ``states`` footprint."""
+
+        for n_oi, batch in (
+            (256, 256),
+            (256, 512),
+            (256, 1000),
+            (256, 4096),
+            (10000, 1000),
+            (65536, 256),
+        ):
+            with self.subTest(n_oi=n_oi, batch=batch):
+                selection = select(n_oi=n_oi, batch=batch).selection
+                self.assertFalse(selection.promoted)
+                self.assertEqual(
+                    selection.selected_padded_rows,
+                    selection.baseline_padded_rows,
+                )
+
+    def test_default_keeps_the_original_program_count_for_256_pair_grids(self) -> None:
+        """A 16x16 PZ layer keeps its baseline batch blocks under the default."""
+
+        selection = select(n_oi=256, batch=1000).selection
+        baseline_block = _select_block_b(256, 1000)
+        self.assertEqual(selection.selected_block, baseline_block)
+        self.assertEqual(
+            selection.n_programs,
+            256 * -(-1000 // baseline_block),
+        )
+
+    def test_default_is_loaded_and_cached_from_package_resources(self) -> None:
+        load_launch_policy.cache_clear()
+        original_files = launch_policy.resources.files
+        with patch.object(
+            launch_policy.resources,
+            "files",
+            wraps=original_files,
+        ) as files:
+            omitted = select(n_oi=256, batch=4096, policy_name=None)
+            explicit = select(
+                n_oi=256,
+                batch=4096,
+                policy_name=POLICY_DEFAULT,
+            )
+        loaded = load_launch_policy(POLICY_DEFAULT)
+        self.assertEqual(files.call_count, 1)
+        self.assertEqual(omitted, explicit)
+        self.assertEqual(loaded.architecture.kind, MatchKind.ANY)
+        self.assertEqual(loaded.match.kind, MatchKind.ANY)
+        self.assertEqual(
+            loaded.block_selector.kind,
+            BlockSelectorKind.ORIGINAL,
+        )
+
+
+class PackagedPolicyTests(unittest.TestCase):
+    def test_n256_policy_has_all_three_exact_configs(self) -> None:
+        expected = LaunchConfig(512, 2, 1, 2)
+        for precision in PrecisionKind:
+            with self.subTest(precision=precision):
+                policy = select(
+                    n_oi=256,
+                    batch=4096,
+                    precision=precision,
+                    policy_name=POLICY_N256,
+                )
+                self.assertEqual(policy.launch, expected)
+                self.assertEqual(policy.policy_name, POLICY_N256)
+
+    def test_n10000_policy_has_dtype_specific_exact_configs(self) -> None:
+        expected = {
+            PrecisionKind.FP32: LaunchConfig(1024, 2, 1, 2),
+            PrecisionKind.BF16: LaunchConfig(1024, 4, 1, 2),
+            PrecisionKind.FP8: LaunchConfig(1024, 2, 1, 2),
+        }
+        for precision, config in expected.items():
+            with self.subTest(precision=precision):
+                policy = select(
+                    n_oi=10000,
+                    batch=1000,
+                    precision=precision,
+                    policy_name=POLICY_N10000,
+                )
+                self.assertEqual(policy.launch, config)
+                self.assertEqual(policy.policy_name, POLICY_N10000)
+
+    def test_n256_batch512_selection_matches_its_document(self) -> None:
+        document = policy_document(POLICY_N256_B512)
+        block_b = document["block_selector"]["block_b"]
+        for precision in PrecisionKind:
+            with self.subTest(precision=precision):
+                metadata = document["precisions"][precision.value]
+                policy = select(
+                    n_oi=256,
+                    batch=512,
+                    precision=precision,
+                    policy_name=POLICY_N256_B512,
+                )
+                self.assertEqual(
+                    policy.launch,
+                    LaunchConfig(
+                        block_b,
+                        metadata["num_warps"],
+                        metadata["waves_per_eu"],
+                        metadata["num_stages"],
+                    ),
+                )
+                self.assertEqual(policy.policy_name, POLICY_N256_B512)
+
+    def test_tuned_policies_never_pad_state_beyond_the_baseline(self) -> None:
+        """Every tuned policy must fit in the original padded-state budget."""
+
+        shapes = {
+            POLICY_N256_B512: (256, 512),
+            POLICY_N256: (256, 4096),
+            POLICY_N10000: (10000, 1000),
+        }
+        for policy_name, (n_oi, batch) in shapes.items():
+            for precision in PrecisionKind:
+                with self.subTest(policy=policy_name, precision=precision):
+                    selection = select(
+                        n_oi=n_oi,
+                        batch=batch,
+                        precision=precision,
+                        policy_name=policy_name,
+                    ).selection
+                    self.assertLessEqual(
+                        selection.selected_padded_rows,
+                        selection.baseline_padded_rows,
+                    )
+
+    def test_explicit_policy_runtime_mismatch_fails_closed(self) -> None:
+        mismatches = (
+            {"architecture": "gfx950"},
+            {"n_oi": 255},
+            {"batch": 4095},
+            {"reps": 2},
+            {"preacts_trainable": True},
+            {"fast_measure": False},
+        )
+        for override in mismatches:
+            kwargs = {
+                "n_oi": 256,
+                "batch": 4096,
+                "architecture": "gfx942",
+                "reps": 3,
+                "preacts_trainable": False,
+                "fast_measure": True,
+                "policy_name": POLICY_N256,
+            }
+            kwargs.update(override)
+            with self.subTest(override=override):
+                with self.assertRaises(LaunchPolicyMismatchError):
+                    select(**kwargs)
+
+    def test_gfx942_policies_do_not_match_a_cuda_runtime(self) -> None:
+        """AMD-tuned policies must never silently apply on NVIDIA."""
+
+        shapes = {
+            POLICY_N256_B512: (256, 512),
+            POLICY_N256: (256, 4096),
+            POLICY_N10000: (10000, 1000),
+        }
+        for policy_name, (n_oi, batch) in shapes.items():
+            with self.subTest(policy=policy_name):
+                with self.assertRaises(LaunchPolicyMismatchError):
+                    select(
+                        n_oi=n_oi,
+                        batch=batch,
+                        architecture="sm90",
+                        policy_name=policy_name,
+                    )
+
+    def test_unknown_and_unsafe_names_fail_closed(self) -> None:
+        with self.assertRaises(LaunchPolicyNotFoundError):
+            load_launch_policy("does-not-exist")
+        for name in ("../escape", "/absolute", "foo.json", "a/b", "..", "UPPER"):
+            with self.subTest(name=name):
+                with self.assertRaises(LaunchPolicyValidationError):
+                    load_launch_policy(name)
+
+    def test_loader_caches_one_parsed_object_per_name(self) -> None:
+        load_launch_policy.cache_clear()
+        original_files = launch_policy.resources.files
+        with patch.object(
+            launch_policy.resources,
+            "files",
+            wraps=original_files,
+        ) as files:
+            first = load_launch_policy(POLICY_N256)
+            second = load_launch_policy(POLICY_N256)
+        self.assertIs(first, second)
+        self.assertEqual(files.call_count, 1)
+
+    def test_every_packaged_policy_loads_and_validates(self) -> None:
+        package = resources.files("qkan.solver.flash.policies")
+        names = {
+            path.name.removesuffix(".json")
+            for path in package.iterdir()
+            if path.name.endswith(".json")
+        }
+        self.assertEqual(
+            names,
+            {POLICY_DEFAULT, POLICY_N256, POLICY_N256_B512, POLICY_N10000},
+        )
+        for name in names:
+            with self.subTest(name=name):
+                self.assertEqual(load_launch_policy(name).name, name)
+
+    def test_vendor_agnostic_policies_do_not_rely_on_amd_only_options(self) -> None:
+        """A policy selectable on any vendor must survive dropping HIP options.
+
+        Architecture-scoped policies cannot reach a foreign backend because
+        selection rejects them, so only ``kind: any`` policies must hold to
+        ``waves_per_eu == 0``, which is exactly what omitting it means.
+        """
+
+        package = resources.files("qkan.solver.flash.policies")
+        agnostic = [
+            policy
+            for path in package.iterdir()
+            if path.name.endswith(".json")
+            for policy in [load_launch_policy(path.name.removesuffix(".json"))]
+            if policy.architecture.kind is MatchKind.ANY
+        ]
+        self.assertEqual([policy.name for policy in agnostic], [POLICY_DEFAULT])
+        for policy in agnostic:
+            for precision, metadata in policy.launch_metadata.items():
+                with self.subTest(policy=policy.name, precision=precision):
+                    self.assertEqual(metadata.waves_per_eu, 0)
+
+    def test_architecture_scoped_policy_is_rejected_on_a_foreign_vendor(self) -> None:
+        with self.assertRaises(LaunchPolicyMismatchError):
+            select_pz_backward_policy(
+                n_oi=256,
+                batch=512,
+                architecture="sm90",
+                precision=PrecisionKind.FP32,
+                reps=3,
+                preacts_trainable=False,
+                fast_measure=True,
+                policy_name=POLICY_N256_B512,
+            )
+
+    def test_packaged_documents_have_no_runtime_provenance(self) -> None:
+        package = resources.files("qkan.solver.flash.policies")
+        names = {POLICY_DEFAULT, POLICY_N256, POLICY_N256_B512, POLICY_N10000}
+        for name in names:
+            text = package.joinpath(f"{name}.json").read_text(encoding="utf-8")
+            with self.subTest(name=name):
+                self.assertNotIn("iteration-", text)
+                self.assertNotIn("/home/", text)
+                self.assertNotIn('"provenance"', text)
+                self.assertNotIn('"source"', text)
+
+
+class SchemaValidationTests(unittest.TestCase):
+    def test_per_precision_blocks_are_strict_and_selectable(self) -> None:
+        document = policy_document(POLICY_N256)
+        name = "synthetic-per-precision"
+        document["name"] = name
+        document["block_selector"] = {"kind": "per_precision"}
+        expected = {
+            "fp32": 32,
+            "bf16": 64,
+            "fp8": 128,
+        }
+        for precision_name, block_b in expected.items():
+            document["precisions"][precision_name]["block_b"] = block_b
+        loaded = validate_launch_policy_document(name, document)
+        self.assertEqual(
+            {
+                precision.value: metadata.block_b
+                for precision, metadata in loaded.launch_metadata.items()
+            },
+            expected,
+        )
+        with patch.object(
+            launch_policy,
+            "load_launch_policy",
+            return_value=loaded,
+        ):
+            for precision in PrecisionKind:
+                with self.subTest(precision=precision):
+                    policy = select(
+                        n_oi=256,
+                        batch=4096,
+                        precision=precision,
+                        policy_name=name,
+                    )
+                    self.assertEqual(
+                        policy.selection.selected_block,
+                        expected[precision.value],
+                    )
+
+    def test_schema_rejects_unknown_missing_and_invalid_fields(self) -> None:
+        base = policy_document(POLICY_N256)
+        mutations = []
+
+        unknown = copy.deepcopy(base)
+        unknown["unexpected"] = True
+        mutations.append(unknown)
+
+        missing = copy.deepcopy(base)
+        del missing["match"]
+        mutations.append(missing)
+
+        wrong_version = copy.deepcopy(base)
+        wrong_version["schema_version"] = 2
+        mutations.append(wrong_version)
+
+        wrong_name = copy.deepcopy(base)
+        wrong_name["name"] = "different-name"
+        mutations.append(wrong_name)
+
+        wrong_operation = copy.deepcopy(base)
+        wrong_operation["operation"] = "other"
+        mutations.append(wrong_operation)
+
+        bad_architecture = copy.deepcopy(base)
+        bad_architecture["architecture"]["value"] = "../gfx942"
+        mutations.append(bad_architecture)
+
+        wrong_type = copy.deepcopy(base)
+        wrong_type["match"]["n_oi"] = True
+        mutations.append(wrong_type)
+
+        missing_precision = copy.deepcopy(base)
+        del missing_precision["precisions"]["fp8"]
+        mutations.append(missing_precision)
+
+        unknown_precision = copy.deepcopy(base)
+        unknown_precision["precisions"]["fp16"] = copy.deepcopy(
+            unknown_precision["precisions"]["fp32"]
+        )
+        mutations.append(unknown_precision)
+
+        bad_block = copy.deepcopy(base)
+        bad_block["block_selector"]["block_b"] = 300
+        mutations.append(bad_block)
+
+        block_in_metadata = copy.deepcopy(base)
+        block_in_metadata["precisions"]["fp32"]["block_b"] = 512
+        mutations.append(block_in_metadata)
+
+        unknown_selector = copy.deepcopy(base)
+        unknown_selector["block_selector"]["kind"] = "adaptive"
+        mutations.append(unknown_selector)
+
+        original_with_block = policy_document(POLICY_DEFAULT)
+        original_with_block["block_selector"]["block_b"] = 128
+        mutations.append(original_with_block)
+
+        any_match_with_shape = policy_document(POLICY_DEFAULT)
+        any_match_with_shape["match"]["n_oi"] = 256
+        mutations.append(any_match_with_shape)
+
+        bad_warps = copy.deepcopy(base)
+        bad_warps["precisions"]["fp32"]["num_warps"] = 3
+        mutations.append(bad_warps)
+
+        bad_stages = copy.deepcopy(base)
+        bad_stages["precisions"]["fp32"]["num_stages"] = 0
+        mutations.append(bad_stages)
+
+        for index, document in enumerate(mutations):
+            with self.subTest(index=index):
+                with self.assertRaises(LaunchPolicyValidationError):
+                    validate_launch_policy_document(POLICY_N256, document)
+
+    def test_architecture_schema_is_not_vendor_hardcoded(self) -> None:
+        document = policy_document(POLICY_N256)
+        document["name"] = "synthetic-sm90-policy"
+        document["architecture"] = {"kind": "exact", "value": "sm90"}
+        loaded = validate_launch_policy_document("synthetic-sm90-policy", document)
+        self.assertEqual(loaded.architecture.value, "sm90")
+
+
+class ConsumerIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        try:
+            self.fused_ops = import_module("qkan.solver.flash.fused_ops")
+        except ImportError as error:  # pragma: no cover - triton is optional
+            self.skipTest(f"triton is unavailable: {error}")
+
+    def test_device_architecture_detection_supports_cuda_sm_names(self) -> None:
+        self.fused_ops._device_properties_snapshot.cache_clear()
+        properties = SimpleNamespace(
+            major=9,
+            minor=0,
+            multi_processor_count=132,
+        )
+        with patch.object(
+            torch.cuda,
+            "get_device_properties",
+            return_value=properties,
+        ):
+            self.assertEqual(
+                self.fused_ops._device_properties_snapshot("cuda", 0),
+                ("sm90", 132),
+            )
+        self.fused_ops._device_properties_snapshot.cache_clear()
+
+    def _clear_launch_caches(self) -> None:
+        self.fused_ops._supports_waves_per_eu.cache_clear()
+        self.fused_ops._warn_waves_per_eu_dropped.cache_clear()
+
+    @contextmanager
+    def _active_backend(self, backend: str, hip_version: str | None):
+        """Run the body against Triton's real ``backend`` options object."""
+
+        gpu_target = import_module("triton.backends.compiler").GPUTarget
+        target = (
+            gpu_target("hip", "gfx942", 64)
+            if backend == "hip"
+            else gpu_target("cuda", 90, 32)
+        )
+        try:
+            self.fused_ops.make_backend(target)
+        except Exception as error:  # pragma: no cover - backend not installed
+            self.skipTest(f"triton {backend} backend unavailable: {error}")
+        driver = SimpleNamespace(
+            active=SimpleNamespace(get_current_target=lambda: target)
+        )
+        self._clear_launch_caches()
+        try:
+            with patch.object(self.fused_ops, "driver", driver):
+                with patch.object(torch.version, "hip", hip_version):
+                    yield
+        finally:
+            self._clear_launch_caches()
+
+    def test_waves_per_eu_is_forwarded_where_the_backend_accepts_it(self) -> None:
+        launch = LaunchConfig(block_b=512, num_warps=2, waves_per_eu=3, num_stages=2)
+        with self._active_backend("hip", "6.2.0"):
+            self.assertEqual(
+                self.fused_ops._launch_options(launch),
+                {"num_warps": 2, "num_stages": 2, "waves_per_eu": 3},
+            )
+
+    def test_waves_per_eu_is_dropped_where_the_backend_rejects_it(self) -> None:
+        """Triton's CUDA options object has no ``waves_per_eu`` field."""
+
+        launch = LaunchConfig(block_b=512, num_warps=2, waves_per_eu=3, num_stages=2)
+        with self._active_backend("cuda", None):
+            with self.assertWarns(RuntimeWarning):
+                options = self.fused_ops._launch_options(launch)
+        self.assertEqual(options, {"num_warps": 2, "num_stages": 2})
+
+    def test_zero_waves_per_eu_is_forwarded_on_hip(self) -> None:
+        """0 is a legal policy value meaning "no occupancy limit" on HIP."""
+
+        launch = LaunchConfig(block_b=128, num_warps=4, waves_per_eu=0, num_stages=2)
+        with self._active_backend("hip", "6.2.0"):
+            self.assertEqual(
+                self.fused_ops._launch_options(launch),
+                {"num_warps": 4, "num_stages": 2, "waves_per_eu": 0},
+            )
+
+    def test_zero_waves_per_eu_is_dropped_without_warning(self) -> None:
+        """Omitting 0 matches the HIP default, so it is not a divergence."""
+
+        launch = LaunchConfig(block_b=128, num_warps=4, waves_per_eu=0, num_stages=2)
+        with self._active_backend("cuda", None):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                options = self.fused_ops._launch_options(launch)
+        self.assertEqual(options, {"num_warps": 4, "num_stages": 2})
+        self.assertEqual(caught, [])
+
+    def test_dropped_waves_per_eu_warns_once_per_value(self) -> None:
+        launch = LaunchConfig(block_b=512, num_warps=2, waves_per_eu=3, num_stages=2)
+        with self._active_backend("cuda", None):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                for _ in range(8):
+                    self.fused_ops._launch_options(launch)
+        self.assertEqual(len(caught), 1)
+        self.assertIn("waves_per_eu=3", str(caught[0].message))
+
+    def test_backend_introspection_outranks_the_torch_build_vendor(self) -> None:
+        """``torch.version.hip`` describes torch, not the Triton backend."""
+
+        launch = LaunchConfig(block_b=512, num_warps=2, waves_per_eu=3, num_stages=2)
+        with self._active_backend("cuda", "6.2.0"):
+            with self.assertWarns(RuntimeWarning):
+                self.assertEqual(
+                    self.fused_ops._launch_options(launch),
+                    {"num_warps": 2, "num_stages": 2},
+                )
+        with self._active_backend("hip", None):
+            self.assertEqual(
+                self.fused_ops._launch_options(launch),
+                {"num_warps": 2, "num_stages": 2, "waves_per_eu": 3},
+            )
+
+    def test_unintrospectable_driver_falls_back_to_the_torch_build(self) -> None:
+        fused_ops = self.fused_ops
+        driver = SimpleNamespace(
+            active=SimpleNamespace(
+                get_current_target=Mock(side_effect=RuntimeError("no driver"))
+            )
+        )
+        launch = LaunchConfig(block_b=512, num_warps=2, waves_per_eu=3, num_stages=2)
+        cases = (
+            ("6.2.0", {"num_warps": 2, "num_stages": 2, "waves_per_eu": 3}),
+            (None, {"num_warps": 2, "num_stages": 2}),
+        )
+        for hip_version, expected in cases:
+            with self.subTest(hip=hip_version):
+                self._clear_launch_caches()
+                with patch.object(fused_ops, "driver", driver):
+                    with patch.object(torch.version, "hip", hip_version):
+                        with warnings.catch_warnings():
+                            warnings.simplefilter("ignore")
+                            options = fused_ops._launch_options(launch)
+                self.assertEqual(options, expected)
+        self._clear_launch_caches()
+
+    def test_public_autograd_path_carries_policy_name_to_backward(self) -> None:
+        flash_module = import_module("qkan.solver.flash.flash")
+        x = torch.zeros(2, 1, requires_grad=True)
+        theta = torch.zeros(1, 1, 4, 2, requires_grad=True)
+        preacts_weight = torch.ones(1, 1, 3)
+        preacts_bias = torch.zeros(1, 1, 3)
+        sentinel = torch.empty(0)
+        with patch.object(
+            flash_module._FlashFunction,
+            "apply",
+            return_value=sentinel,
+        ) as apply:
+            result = flash_module.flash_exact_solver(
+                x,
+                theta,
+                preacts_weight,
+                preacts_bias,
+                3,
+                ansatz="pz",
+                out_dim=1,
+                dtype=torch.float32,
+                pz_launch_policy=POLICY_N256,
+            )
+        self.assertIs(result, sentinel)
+        self.assertEqual(apply.call_args.args[-1], POLICY_N256)
+
+        with patch.object(
+            flash_module._FlashFunction,
+            "apply",
+            return_value=sentinel,
+        ) as default_apply:
+            flash_module.flash_exact_solver(
+                x,
+                theta,
+                preacts_weight,
+                preacts_bias,
+                3,
+                ansatz="pz",
+                out_dim=1,
+                dtype=torch.float32,
+            )
+        self.assertIsNone(default_apply.call_args.args[-1])
+
+        ctx = SimpleNamespace(
+            saved_tensors=(x, theta, preacts_weight, preacts_bias),
+            ansatz="pz",
+            preacts_trainable=False,
+            fast_measure=True,
+            c_dtype=torch.float32,
+            pz_launch_policy=POLICY_N256,
+        )
+        gradients = (
+            torch.zeros_like(x),
+            torch.zeros_like(theta),
+            None,
+            None,
+        )
+        with patch.object(
+            flash_module,
+            "triton_pz_backward",
+            return_value=gradients,
+        ) as backward:
+            returned = flash_module._FlashFunction.backward(ctx, torch.zeros(2, 1, 1))
+        self.assertEqual(backward.call_args.kwargs["policy_name"], POLICY_N256)
+        self.assertEqual(len(returned), 11)
+
+    def test_policy_name_is_rejected_for_non_pz_ansatz(self) -> None:
+        flash_module = import_module("qkan.solver.flash.flash")
+        with self.assertRaises(ValueError):
+            flash_module.flash_exact_solver(
+                torch.zeros(2, 1),
+                torch.zeros(1, 1, 4, 2),
+                torch.ones(1, 1, 3),
+                torch.zeros(1, 1, 3),
+                3,
+                ansatz="rpz",
+                out_dim=1,
+                dtype=torch.float32,
+                pz_launch_policy=POLICY_N256,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/qkan/solver/flash/flash.py
+++ b/src/qkan/solver/flash/flash.py
@@ -58,6 +58,7 @@ class _FlashFunction(torch.autograd.Function):
         out_dim,
         c_dtype,
         ansatz,
+        pz_launch_policy,
     ):
         ctx.save_for_backward(x, theta, preacts_w, preacts_b)
         ctx.reps = reps
@@ -66,6 +67,7 @@ class _FlashFunction(torch.autograd.Function):
         ctx.out_dim = out_dim
         ctx.c_dtype = c_dtype
         ctx.ansatz = ansatz
+        ctx.pz_launch_policy = pz_launch_policy
 
         if ansatz in ("pz_encoding", "pz"):
             return triton_pz_forward(
@@ -114,6 +116,7 @@ class _FlashFunction(torch.autograd.Function):
                 ctx.preacts_trainable,
                 ctx.fast_measure,
                 c_dtype=ctx.c_dtype,
+                policy_name=ctx.pz_launch_policy,
             )
         elif ansatz in ("rpz_encoding", "rpz"):
             grad_x, grad_theta, grad_pw, grad_pb = triton_rpz_backward(
@@ -155,6 +158,7 @@ class _FlashFunction(torch.autograd.Function):
             None,  # out_dim
             None,  # c_dtype
             None,  # ansatz
+            None,  # pz_launch_policy
         )
 
 
@@ -188,7 +192,11 @@ def flash_exact_solver(
     fast_measure = kwargs.get("fast_measure", True)
     out_dim: int = kwargs.get("out_dim", x.shape[1])
     c_dtype = kwargs.get("dtype", torch.complex64)
+    pz_launch_policy = kwargs.get("pz_launch_policy")
     batch, in_dim = x.shape
+
+    if pz_launch_policy is not None and ansatz not in ("pz_encoding", "pz"):
+        raise ValueError("pz_launch_policy is only valid for the PZ ansatz")
 
     # Fallback for unsupported ansatzes
     if ansatz not in _SUPPORTED_FLASH_ANSATZES:
@@ -242,6 +250,7 @@ def flash_exact_solver(
             out_dim,
             c_dtype,
             ansatz,
+            pz_launch_policy,
         )
     else:
         if ansatz in ("pz_encoding", "pz"):

--- a/src/qkan/solver/flash/fused_ops.py
+++ b/src/qkan/solver/flash/fused_ops.py
@@ -1874,7 +1874,17 @@ def triton_pz_backward(
     grad_output = grad_output.contiguous()
 
     n_oi = out_dim * in_dim
-    BLOCK_B = _select_block_b(n_oi, batch)
+    # B5's 10,000-way grid has enough independent work to fill the device.
+    # A 256-lane tile halves batch-block programs and scalar gradient atomics
+    # without increasing padded state storage (1000 rounds to 1024 either way).
+    large_pz = n_oi >= 256 and batch >= 256
+    BLOCK_B = 1024 if large_pz else _select_block_b(n_oi, batch)
+    if large_pz:
+        NUM_WARPS = 4 if c_dtype == torch.bfloat16 else 2
+    else:
+        NUM_WARPS = 4
+    WAVES_PER_EU = 1 if large_pz else 0
+    NUM_STAGES = 2
     n_states = 3 * reps + 3  # H state + 3 per layer + after final Rz
     n_b_blocks = triton.cdiv(batch, BLOCK_B)
     n_programs = n_oi * n_b_blocks
@@ -1953,6 +1963,9 @@ def triton_pz_backward(
         FAST_MEASURE=fast_measure,
         FP8_PRESCALE=224.0 if compute_fp8 else 1.0,
         BLOCK_B=BLOCK_B,
+        num_warps=NUM_WARPS,
+        waves_per_eu=WAVES_PER_EU,
+        num_stages=NUM_STAGES,
     )
 
     return (

--- a/src/qkan/solver/flash/fused_ops.py
+++ b/src/qkan/solver/flash/fused_ops.py
@@ -19,11 +19,139 @@ Implements pz_encoding, rpz_encoding, and real ansatz forward passes as fused
 Triton kernels, avoiding materialization of intermediate complex state vectors.
 """
 
+import warnings
+from dataclasses import dataclass
+from functools import lru_cache
+
 import torch
 import triton  # type: ignore
 import triton.language as tl  # type: ignore
+from triton.compiler import make_backend  # type: ignore
+from triton.runtime import driver  # type: ignore
 
 from qkan._kernel_utils import _select_block_b
+from qkan.solver.flash.launch_policy import (
+    LaunchConfig,
+    PrecisionKind,
+    PzBackwardPolicy,
+    normalized_architecture,
+    select_pz_backward_policy,
+)
+
+
+@dataclass(frozen=True)
+class _DeviceLaunchContext:
+    device_type: str
+    device_index: int
+    architecture: str
+    multi_processor_count: int
+
+
+@lru_cache(maxsize=None)
+def _device_properties_snapshot(device_type: str, device_index: int) -> tuple[str, int]:
+    if device_type != "cuda":
+        return "unknown", 1
+    properties = torch.cuda.get_device_properties(device_index)
+    architecture = getattr(properties, "gcnArchName", None) or getattr(
+        properties, "gcn_arch_name", None
+    )
+    if architecture is None:
+        major = getattr(properties, "major", None)
+        minor = getattr(properties, "minor", None)
+        if type(major) is int and type(minor) is int:
+            architecture = f"sm{major}{minor}"
+    return normalized_architecture(architecture), int(properties.multi_processor_count)
+
+
+@lru_cache(maxsize=None)
+def _device_launch_context_from_snapshot(
+    device_type: str,
+    device_index: int,
+    architecture: str,
+    multi_processor_count: int,
+) -> _DeviceLaunchContext:
+    return _DeviceLaunchContext(
+        device_type=device_type,
+        device_index=device_index,
+        architecture=architecture,
+        multi_processor_count=multi_processor_count,
+    )
+
+
+def _device_launch_context(device: torch.device) -> _DeviceLaunchContext:
+    index = device.index
+    if index is None:
+        index = torch.cuda.current_device() if device.type == "cuda" else 0
+    architecture, count = _device_properties_snapshot(device.type, index)
+    return _device_launch_context_from_snapshot(device.type, index, architecture, count)
+
+
+def _precision_kind(c_dtype: torch.dtype) -> PrecisionKind:
+    if c_dtype == torch.float8_e4m3fn:
+        return PrecisionKind.FP8
+    if c_dtype == torch.bfloat16:
+        return PrecisionKind.BF16
+    if c_dtype == torch.float32:
+        return PrecisionKind.FP32
+    raise ValueError(f"unsupported PZ backward dtype: {c_dtype}")
+
+
+def _torch_dtype(name: str) -> torch.dtype:
+    return {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float8_e4m3fn": torch.float8_e4m3fn,
+    }[name]
+
+
+@lru_cache(maxsize=None)
+def _supports_waves_per_eu() -> bool:
+    """Report whether the active Triton backend accepts ``waves_per_eu``.
+
+    ``waves_per_eu`` is AMD/HIP-only and Triton's JIT raises ``KeyError`` for
+    any launch keyword missing from its backend's options object, so ask that
+    backend rather than inferring the vendor from ``torch.version``. Testing
+    ``__dict__`` mirrors the JIT's own check and so also covers fields set
+    outside the dataclass declaration. The accepted set belongs to the backend
+    vendor, of which a process resolves exactly one, so caching it process-
+    wide stays correct across devices.
+    """
+
+    try:
+        target = driver.active.get_current_target()
+        options = make_backend(target).parse_options({})
+    except Exception:  # pragma: no cover - requires an unloadable driver
+        return torch.version.hip is not None
+    return "waves_per_eu" in options.__dict__
+
+
+@lru_cache(maxsize=None)
+def _warn_waves_per_eu_dropped(waves_per_eu: int) -> None:
+    """Warn once per value that a policy's ``waves_per_eu`` was not applied."""
+
+    warnings.warn(
+        f"launch policy requested waves_per_eu={waves_per_eu}, which the "
+        "active Triton backend does not accept; launching without it",
+        RuntimeWarning,
+        stacklevel=3,
+    )
+
+
+def _launch_options(launch: LaunchConfig) -> dict[str, int]:
+    """Build the Triton launch keywords a policy asks for on this backend.
+
+    ``num_warps`` and ``num_stages`` are portable. ``waves_per_eu`` is passed
+    through verbatim where it is accepted, including 0, which the HIP backend
+    treats as "no occupancy limit" and is also its default. Elsewhere it is
+    dropped, and only a non-zero request diverges from the tuned policy.
+    """
+
+    options = {"num_warps": launch.num_warps, "num_stages": launch.num_stages}
+    if _supports_waves_per_eu():
+        options["waves_per_eu"] = launch.waves_per_eu
+    elif launch.waves_per_eu:
+        _warn_waves_per_eu_dropped(launch.waves_per_eu)
+    return options
 
 
 @triton.jit
@@ -1862,40 +1990,37 @@ def triton_pz_backward(
     preacts_trainable,
     fast_measure,
     c_dtype=torch.float32,
+    policy_name: str | None = None,
 ):
     """Launch pz_encoding backward kernel. Returns (grad_x, grad_theta, grad_pw, grad_pb)."""
     batch, in_dim = x.shape
     out_dim = theta.shape[0]
     reps = theta.shape[2] - 1
 
-    io_dtype = torch.bfloat16 if c_dtype == torch.float8_e4m3fn else c_dtype
+    precision_kind = _precision_kind(c_dtype)
+    architecture = _device_launch_context(x.device).architecture
+    policy: PzBackwardPolicy = select_pz_backward_policy(
+        n_oi=out_dim * in_dim,
+        batch=batch,
+        architecture=architecture,
+        precision=precision_kind,
+        reps=reps,
+        preacts_trainable=preacts_trainable,
+        fast_measure=fast_measure,
+        policy_name=policy_name,
+    )
+    io_dtype = _torch_dtype(policy.precision.io_dtype_name)
     x = x.to(io_dtype).contiguous()
     theta = theta.to(io_dtype).contiguous()
     grad_output = grad_output.contiguous()
 
     n_oi = out_dim * in_dim
-    # B5's 10,000-way grid has enough independent work to fill the device.
-    # A 256-lane tile halves batch-block programs and scalar gradient atomics
-    # without increasing padded state storage (1000 rounds to 1024 either way).
-    large_pz = n_oi >= 256 and batch >= 256
-    BLOCK_B = 1024 if large_pz else _select_block_b(n_oi, batch)
-    if large_pz:
-        NUM_WARPS = 4 if c_dtype == torch.bfloat16 else 2
-    else:
-        NUM_WARPS = 4
-    WAVES_PER_EU = 1 if large_pz else 0
-    NUM_STAGES = 2
+    BLOCK_B = policy.launch.block_b
+    launch_options = _launch_options(policy.launch)
     n_states = 3 * reps + 3  # H state + 3 per layer + after final Rz
-    n_b_blocks = triton.cdiv(batch, BLOCK_B)
+    n_b_blocks = policy.selection.n_b_blocks
     n_programs = n_oi * n_b_blocks
-    compute_fp8 = c_dtype == torch.float8_e4m3fn
-    io_dtype = torch.bfloat16 if compute_fp8 else c_dtype
-    if compute_fp8:
-        states_dtype = torch.float8_e4m3fn
-    elif c_dtype == torch.bfloat16:
-        states_dtype = torch.bfloat16
-    else:
-        states_dtype = torch.float32
+    states_dtype = _torch_dtype(policy.precision.state_dtype_name)
     states = torch.empty(
         n_programs, n_states, 4, BLOCK_B, device=x.device, dtype=states_dtype
     )
@@ -1961,11 +2086,9 @@ def triton_pz_backward(
         *gpb_strides,
         PREACTS_TRAINABLE=preacts_trainable,
         FAST_MEASURE=fast_measure,
-        FP8_PRESCALE=224.0 if compute_fp8 else 1.0,
+        FP8_PRESCALE=policy.precision.fp8_prescale,
         BLOCK_B=BLOCK_B,
-        num_warps=NUM_WARPS,
-        waves_per_eu=WAVES_PER_EU,
-        num_stages=NUM_STAGES,
+        **launch_options,
     )
 
     return (

--- a/src/qkan/solver/flash/launch_policy.py
+++ b/src/qkan/solver/flash/launch_policy.py
@@ -1,0 +1,684 @@
+"""Select and load PZ backward launch policies.
+
+Public callers select a policy with
+``flash_exact_solver(..., pz_launch_policy=None)``; ``None`` and ``"default"``
+are equivalent. The packaged ``flash/policies/default.json`` retains the
+original ``_select_block_b`` selector and its default launch metadata.
+
+Pass a tuned package-resource name without ``.json``, for example::
+
+    policy = "pz-gfx942-n256-batch4096-r3-fixed-preacts-fast-v1"
+    flash_exact_solver(..., pz_launch_policy=policy)
+
+An explicit named policy is loaded from ``flash/policies/<name>.json``,
+strictly validated, and cached. Its architecture, shape, repetitions, and mode
+(``preacts_trainable`` and ``fast_measure``) must match the runtime; a mismatch
+raises an error instead of silently falling back. To add a future tuning, add
+its JSON resource and pass its name. The benchmark CLI accepts the same name
+through ``benchmark_qkan_solver.py --pz-launch-policy <name>``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from functools import lru_cache
+from importlib import resources
+from types import MappingProxyType
+from typing import Any
+
+from qkan._kernel_utils import _select_block_b
+
+_POLICY_PACKAGE = "qkan.solver.flash.policies"
+_POLICY_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+_PRECISION_NAMES = frozenset(("fp32", "bf16", "fp8"))
+
+
+class PrecisionKind(str, Enum):
+    FP32 = "fp32"
+    BF16 = "bf16"
+    FP8 = "fp8"
+
+
+class MatchKind(str, Enum):
+    ANY = "any"
+    EXACT = "exact"
+
+
+class BlockSelectorKind(str, Enum):
+    ORIGINAL = "original"
+    FIXED = "fixed"
+    PER_PRECISION = "per_precision"
+
+
+@dataclass(frozen=True)
+class PrecisionPlan:
+    """Current observable precision behavior plus its launch-table key."""
+
+    kind: PrecisionKind
+    io_dtype_name: str
+    state_dtype_name: str
+    state_itemsize: int
+    fp8_prescale: float
+    launch_precision_key: str
+
+
+@dataclass(frozen=True)
+class ShapeSelection:
+    baseline_block: int
+    selected_block: int
+    baseline_padded_rows: int
+    selected_padded_rows: int
+    n_b_blocks: int
+    n_programs: int
+    promoted: bool
+
+
+@dataclass(frozen=True)
+class LaunchConfig:
+    block_b: int
+    num_warps: int
+    waves_per_eu: int
+    num_stages: int
+
+
+@dataclass(frozen=True)
+class LaunchMetadata:
+    block_b: int | None
+    num_warps: int
+    waves_per_eu: int
+    num_stages: int
+
+
+@dataclass(frozen=True)
+class ArchitectureMatch:
+    kind: MatchKind
+    value: str | None
+
+
+@dataclass(frozen=True)
+class PolicyMatch:
+    kind: MatchKind
+    n_oi: int | None
+    batch: int | None
+    reps: int | None
+    preacts_trainable: bool | None
+    fast_measure: bool | None
+
+
+@dataclass(frozen=True)
+class BlockSelector:
+    kind: BlockSelectorKind
+    block_b: int | None
+
+
+@dataclass(frozen=True)
+class LoadedLaunchPolicy:
+    schema_version: int
+    name: str
+    operation: str
+    architecture: ArchitectureMatch
+    match: PolicyMatch
+    block_selector: BlockSelector
+    launch_metadata: Mapping[PrecisionKind, LaunchMetadata]
+    description: str | None
+
+
+@dataclass(frozen=True)
+class PzBackwardPolicy:
+    architecture: str
+    precision: PrecisionPlan
+    selection: ShapeSelection
+    launch: LaunchConfig
+    policy_name: str
+
+
+class LaunchPolicyError(ValueError):
+    """Base class for explicit launch-policy failures."""
+
+
+class LaunchPolicyNotFoundError(LaunchPolicyError):
+    pass
+
+
+class LaunchPolicyValidationError(LaunchPolicyError):
+    pass
+
+
+class LaunchPolicyMismatchError(LaunchPolicyError):
+    pass
+
+
+PRECISION_PLANS: Mapping[PrecisionKind, PrecisionPlan] = MappingProxyType(
+    {
+        PrecisionKind.FP32: PrecisionPlan(
+            kind=PrecisionKind.FP32,
+            io_dtype_name="float32",
+            state_dtype_name="float32",
+            state_itemsize=4,
+            fp8_prescale=1.0,
+            launch_precision_key="fp32",
+        ),
+        PrecisionKind.BF16: PrecisionPlan(
+            kind=PrecisionKind.BF16,
+            io_dtype_name="bfloat16",
+            state_dtype_name="bfloat16",
+            state_itemsize=2,
+            fp8_prescale=1.0,
+            launch_precision_key="bf16",
+        ),
+        PrecisionKind.FP8: PrecisionPlan(
+            kind=PrecisionKind.FP8,
+            io_dtype_name="bfloat16",
+            state_dtype_name="float8_e4m3fn",
+            state_itemsize=1,
+            fp8_prescale=224.0,
+            launch_precision_key="fp8",
+        ),
+    }
+)
+
+_ROOT_REQUIRED_KEYS = frozenset(
+    (
+        "schema_version",
+        "name",
+        "operation",
+        "architecture",
+        "match",
+        "block_selector",
+        "precisions",
+    )
+)
+_ROOT_OPTIONAL_KEYS = frozenset(("description",))
+_ARCHITECTURE_EXACT_KEYS = frozenset(("kind", "value"))
+_MATCH_EXACT_KEYS = frozenset(
+    ("kind", "n_oi", "batch", "reps", "preacts_trainable", "fast_measure")
+)
+_BLOCK_FIXED_KEYS = frozenset(("kind", "block_b"))
+_LAUNCH_METADATA_KEYS = frozenset(("num_warps", "waves_per_eu", "num_stages"))
+_LAUNCH_METADATA_WITH_BLOCK_KEYS = frozenset(
+    ("block_b", "num_warps", "waves_per_eu", "num_stages")
+)
+
+
+def _policy_error(policy_name: str, message: str) -> LaunchPolicyValidationError:
+    return LaunchPolicyValidationError(
+        f"launch policy {policy_name!r} is invalid: {message}"
+    )
+
+
+def _require_object(value: object, policy_name: str, context: str) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise _policy_error(policy_name, f"{context} must be an object")
+    return value
+
+
+def _require_exact_keys(
+    value: Mapping[str, object],
+    *,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+    policy_name: str,
+    context: str,
+) -> None:
+    keys = set(value)
+    missing = sorted(required - keys)
+    unknown = sorted(keys - required - optional)
+    if missing:
+        raise _policy_error(policy_name, f"{context} is missing keys {missing}")
+    if unknown:
+        raise _policy_error(policy_name, f"{context} has unknown keys {unknown}")
+
+
+def _require_string(value: object, policy_name: str, context: str) -> str:
+    if type(value) is not str or not value:
+        raise _policy_error(policy_name, f"{context} must be a non-empty string")
+    return value
+
+
+def _require_int(value: object, policy_name: str, context: str) -> int:
+    if type(value) is not int:
+        raise _policy_error(policy_name, f"{context} must be an integer")
+    return value
+
+
+def _require_bool(value: object, policy_name: str, context: str) -> bool:
+    if type(value) is not bool:
+        raise _policy_error(policy_name, f"{context} must be a boolean")
+    return value
+
+
+def _validate_policy_name(policy_name: object) -> str:
+    if type(policy_name) is not str or not _POLICY_NAME_PATTERN.fullmatch(policy_name):
+        raise LaunchPolicyValidationError(
+            "policy name must match ^[a-z0-9][a-z0-9_-]{0,127}$"
+        )
+    return policy_name
+
+
+def normalize_policy_name(policy_name: str | None) -> str:
+    """Map the omitted public value to its packaged policy name."""
+
+    return "default" if policy_name is None else _validate_policy_name(policy_name)
+
+
+def _parse_launch_metadata(
+    policy_name: str,
+    precision_name: str,
+    value: object,
+    *,
+    requires_block: bool,
+) -> LaunchMetadata:
+    context = f"precisions.{precision_name}"
+    config = _require_object(value, policy_name, context)
+    _require_exact_keys(
+        config,
+        required=(
+            _LAUNCH_METADATA_WITH_BLOCK_KEYS
+            if requires_block
+            else _LAUNCH_METADATA_KEYS
+        ),
+        policy_name=policy_name,
+        context=context,
+    )
+    num_warps = _require_int(config["num_warps"], policy_name, f"{context}.num_warps")
+    waves_per_eu = _require_int(
+        config["waves_per_eu"], policy_name, f"{context}.waves_per_eu"
+    )
+    num_stages = _require_int(
+        config["num_stages"], policy_name, f"{context}.num_stages"
+    )
+    block_b = None
+    if requires_block:
+        block_b = _require_int(config["block_b"], policy_name, f"{context}.block_b")
+        if block_b <= 0 or block_b > 65536 or block_b & (block_b - 1):
+            raise _policy_error(
+                policy_name,
+                f"{context}.block_b must be a power of two from 1 to 65536",
+            )
+    if num_warps <= 0 or num_warps > 32 or num_warps & (num_warps - 1):
+        raise _policy_error(
+            policy_name,
+            f"{context}.num_warps must be a power of two from 1 to 32",
+        )
+    if not 0 <= waves_per_eu <= 16:
+        raise _policy_error(
+            policy_name,
+            f"{context}.waves_per_eu must be from 0 to 16",
+        )
+    if not 1 <= num_stages <= 16:
+        raise _policy_error(
+            policy_name,
+            f"{context}.num_stages must be from 1 to 16",
+        )
+    return LaunchMetadata(block_b, num_warps, waves_per_eu, num_stages)
+
+
+def _parse_match_kind(
+    value: object,
+    policy_name: str,
+    context: str,
+) -> MatchKind:
+    raw_kind = _require_string(value, policy_name, f"{context}.kind")
+    try:
+        return MatchKind(raw_kind)
+    except ValueError as error:
+        raise _policy_error(
+            policy_name,
+            f"{context}.kind must be 'any' or 'exact'",
+        ) from error
+
+
+def _parse_architecture_match(
+    policy_name: str,
+    value: object,
+) -> ArchitectureMatch:
+    context = "architecture"
+    document = _require_object(value, policy_name, context)
+    kind = _parse_match_kind(document.get("kind"), policy_name, context)
+    required = (
+        frozenset(("kind",)) if kind is MatchKind.ANY else _ARCHITECTURE_EXACT_KEYS
+    )
+    _require_exact_keys(
+        document,
+        required=required,
+        policy_name=policy_name,
+        context=context,
+    )
+    if kind is MatchKind.ANY:
+        return ArchitectureMatch(kind=kind, value=None)
+    architecture = _require_string(document["value"], policy_name, "architecture.value")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,63}", architecture):
+        raise _policy_error(
+            policy_name,
+            "architecture.value contains unsupported characters",
+        )
+    return ArchitectureMatch(kind=kind, value=architecture)
+
+
+def _parse_policy_match(policy_name: str, value: object) -> PolicyMatch:
+    context = "match"
+    document = _require_object(value, policy_name, context)
+    kind = _parse_match_kind(document.get("kind"), policy_name, context)
+    required = frozenset(("kind",)) if kind is MatchKind.ANY else _MATCH_EXACT_KEYS
+    _require_exact_keys(
+        document,
+        required=required,
+        policy_name=policy_name,
+        context=context,
+    )
+    if kind is MatchKind.ANY:
+        return PolicyMatch(kind, None, None, None, None, None)
+    match = PolicyMatch(
+        kind=kind,
+        n_oi=_require_int(document["n_oi"], policy_name, "match.n_oi"),
+        batch=_require_int(document["batch"], policy_name, "match.batch"),
+        reps=_require_int(document["reps"], policy_name, "match.reps"),
+        preacts_trainable=_require_bool(
+            document["preacts_trainable"],
+            policy_name,
+            "match.preacts_trainable",
+        ),
+        fast_measure=_require_bool(
+            document["fast_measure"],
+            policy_name,
+            "match.fast_measure",
+        ),
+    )
+    if (
+        match.n_oi is None
+        or match.batch is None
+        or match.reps is None
+        or match.n_oi <= 0
+        or match.batch <= 0
+        or match.reps <= 0
+    ):
+        raise _policy_error(
+            policy_name,
+            "match.n_oi, match.batch, and match.reps must be positive",
+        )
+    return match
+
+
+def _parse_block_selector(
+    policy_name: str,
+    value: object,
+) -> BlockSelector:
+    context = "block_selector"
+    document = _require_object(value, policy_name, context)
+    raw_kind = _require_string(document.get("kind"), policy_name, f"{context}.kind")
+    try:
+        kind = BlockSelectorKind(raw_kind)
+    except ValueError as error:
+        raise _policy_error(
+            policy_name,
+            "block_selector.kind must be 'original', 'fixed', or 'per_precision'",
+        ) from error
+    required = (
+        frozenset(("kind",))
+        if kind
+        in (
+            BlockSelectorKind.ORIGINAL,
+            BlockSelectorKind.PER_PRECISION,
+        )
+        else _BLOCK_FIXED_KEYS
+    )
+    _require_exact_keys(
+        document,
+        required=required,
+        policy_name=policy_name,
+        context=context,
+    )
+    if kind in (
+        BlockSelectorKind.ORIGINAL,
+        BlockSelectorKind.PER_PRECISION,
+    ):
+        return BlockSelector(kind=kind, block_b=None)
+    block_b = _require_int(document["block_b"], policy_name, "block_selector.block_b")
+    if block_b <= 0 or block_b > 65536 or block_b & (block_b - 1):
+        raise _policy_error(
+            policy_name,
+            "block_selector.block_b must be a power of two from 1 to 65536",
+        )
+    return BlockSelector(kind=kind, block_b=block_b)
+
+
+def validate_launch_policy_document(
+    policy_name: str,
+    document: object,
+) -> LoadedLaunchPolicy:
+    """Validate one already-decoded package policy document."""
+
+    policy_name = _validate_policy_name(policy_name)
+    root = _require_object(document, policy_name, "document")
+    _require_exact_keys(
+        root,
+        required=_ROOT_REQUIRED_KEYS,
+        optional=_ROOT_OPTIONAL_KEYS,
+        policy_name=policy_name,
+        context="document",
+    )
+    schema_version = _require_int(root["schema_version"], policy_name, "schema_version")
+    if schema_version != 1:
+        raise _policy_error(policy_name, "schema_version must be 1")
+    document_name = _require_string(root["name"], policy_name, "name")
+    if document_name != policy_name:
+        raise _policy_error(
+            policy_name,
+            f"name {document_name!r} does not match the requested policy name",
+        )
+    operation = _require_string(root["operation"], policy_name, "operation")
+    if operation != "pz_backward":
+        raise _policy_error(policy_name, "operation must be 'pz_backward'")
+    architecture = _parse_architecture_match(policy_name, root["architecture"])
+    match = _parse_policy_match(policy_name, root["match"])
+    block_selector = _parse_block_selector(policy_name, root["block_selector"])
+
+    precision_document = _require_object(root["precisions"], policy_name, "precisions")
+    _require_exact_keys(
+        precision_document,
+        required=_PRECISION_NAMES,
+        policy_name=policy_name,
+        context="precisions",
+    )
+    launch_metadata = MappingProxyType(
+        {
+            PrecisionKind(precision_name): _parse_launch_metadata(
+                policy_name,
+                precision_name,
+                precision_document[precision_name],
+                requires_block=(block_selector.kind is BlockSelectorKind.PER_PRECISION),
+            )
+            for precision_name in sorted(_PRECISION_NAMES)
+        }
+    )
+    description = root.get("description")
+    if description is not None:
+        description = _require_string(description, policy_name, "description")
+    return LoadedLaunchPolicy(
+        schema_version=schema_version,
+        name=document_name,
+        operation=operation,
+        architecture=architecture,
+        match=match,
+        block_selector=block_selector,
+        launch_metadata=launch_metadata,
+        description=description,
+    )
+
+
+@lru_cache(maxsize=None)
+def load_launch_policy(policy_name: str) -> LoadedLaunchPolicy:
+    """Load and validate one named policy from package resources."""
+
+    policy_name = _validate_policy_name(policy_name)
+    filename = f"{policy_name}.json"
+    try:
+        text = (
+            resources.files(_POLICY_PACKAGE)
+            .joinpath(filename)
+            .read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, ModuleNotFoundError) as error:
+        raise LaunchPolicyNotFoundError(
+            f"launch policy {policy_name!r} does not exist"
+        ) from error
+    except OSError as error:
+        raise LaunchPolicyError(
+            f"failed to read launch policy {policy_name!r}: {error}"
+        ) from error
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise LaunchPolicyValidationError(
+            f"launch policy {policy_name!r} contains invalid JSON: {error.msg}"
+        ) from error
+    return validate_launch_policy_document(policy_name, document)
+
+
+def _ceil_div(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+def padded_rows(batch: int, block_b: int) -> int:
+    return _ceil_div(batch, block_b) * block_b
+
+
+def precision_plan(kind: PrecisionKind) -> PrecisionPlan:
+    return PRECISION_PLANS[kind]
+
+
+def normalized_architecture(architecture: str | None) -> str:
+    return (architecture or "unknown").split(":", 1)[0]
+
+
+def _shape_selection(n_oi: int, batch: int, selected_block: int) -> ShapeSelection:
+    baseline_block = _select_block_b(n_oi, batch)
+    n_b_blocks = _ceil_div(batch, selected_block)
+    return ShapeSelection(
+        baseline_block=baseline_block,
+        selected_block=selected_block,
+        baseline_padded_rows=padded_rows(batch, baseline_block),
+        selected_padded_rows=padded_rows(batch, selected_block),
+        n_b_blocks=n_b_blocks,
+        n_programs=n_oi * n_b_blocks,
+        promoted=selected_block != baseline_block,
+    )
+
+
+def _validate_runtime_match(
+    policy: LoadedLaunchPolicy,
+    *,
+    architecture: str,
+    n_oi: int,
+    batch: int,
+    reps: int,
+    preacts_trainable: bool,
+    fast_measure: bool,
+) -> None:
+    runtime_values = {
+        "architecture": architecture,
+        "n_oi": n_oi,
+        "batch": batch,
+        "reps": reps,
+        "preacts_trainable": preacts_trainable,
+        "fast_measure": fast_measure,
+    }
+    expected_values: dict[str, object] = {}
+    if policy.architecture.kind is MatchKind.EXACT:
+        expected_values["architecture"] = policy.architecture.value
+    if policy.match.kind is MatchKind.EXACT:
+        expected_values.update(
+            {
+                "n_oi": policy.match.n_oi,
+                "batch": policy.match.batch,
+                "reps": policy.match.reps,
+                "preacts_trainable": policy.match.preacts_trainable,
+                "fast_measure": policy.match.fast_measure,
+            }
+        )
+    mismatches = [
+        f"{field} expected {expected_values[field]!r}, got {runtime_values[field]!r}"
+        for field in expected_values
+        if expected_values[field] != runtime_values[field]
+    ]
+    if mismatches:
+        raise LaunchPolicyMismatchError(
+            f"launch policy {policy.name!r} does not match runtime: "
+            + "; ".join(mismatches)
+        )
+
+
+def _select_policy_block(
+    policy: LoadedLaunchPolicy,
+    precision: PrecisionKind,
+    n_oi: int,
+    batch: int,
+) -> int:
+    if policy.block_selector.kind is BlockSelectorKind.ORIGINAL:
+        return _select_block_b(n_oi, batch)
+    if policy.block_selector.kind is BlockSelectorKind.PER_PRECISION:
+        block_b = policy.launch_metadata[precision].block_b
+        if block_b is None:
+            raise LaunchPolicyValidationError(
+                f"launch policy {policy.name!r} has no block_b for "
+                f"precision {precision.value!r}"
+            )
+        return block_b
+    if policy.block_selector.block_b is None:
+        raise LaunchPolicyValidationError(
+            f"launch policy {policy.name!r} has no fixed block_b"
+        )
+    return policy.block_selector.block_b
+
+
+def select_pz_backward_policy(
+    *,
+    n_oi: int,
+    batch: int,
+    architecture: str | None,
+    precision: PrecisionKind,
+    reps: int,
+    preacts_trainable: bool,
+    fast_measure: bool,
+    policy_name: str | None = None,
+) -> PzBackwardPolicy:
+    if n_oi <= 0 or batch <= 0 or reps <= 0:
+        raise ValueError("n_oi, batch, and reps must be positive")
+    arch = normalized_architecture(architecture)
+    plan = precision_plan(precision)
+    resolved_policy_name = normalize_policy_name(policy_name)
+    loaded_policy = load_launch_policy(resolved_policy_name)
+    _validate_runtime_match(
+        loaded_policy,
+        architecture=arch,
+        n_oi=n_oi,
+        batch=batch,
+        reps=reps,
+        preacts_trainable=preacts_trainable,
+        fast_measure=fast_measure,
+    )
+    selected_block = _select_policy_block(
+        loaded_policy,
+        precision,
+        n_oi,
+        batch,
+    )
+    metadata = loaded_policy.launch_metadata[precision]
+    launch = LaunchConfig(
+        block_b=selected_block,
+        num_warps=metadata.num_warps,
+        waves_per_eu=metadata.waves_per_eu,
+        num_stages=metadata.num_stages,
+    )
+    selection = _shape_selection(n_oi, batch, selected_block)
+    return PzBackwardPolicy(
+        architecture=arch,
+        precision=plan,
+        selection=selection,
+        launch=launch,
+        policy_name=resolved_policy_name,
+    )

--- a/src/qkan/solver/flash/policies/__init__.py
+++ b/src/qkan/solver/flash/policies/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged, explicitly selected PZ backward launch policies."""

--- a/src/qkan/solver/flash/policies/default.json
+++ b/src/qkan/solver/flash/policies/default.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "name": "default",
+  "operation": "pz_backward",
+  "architecture": {
+    "kind": "any"
+  },
+  "match": {
+    "kind": "any"
+  },
+  "block_selector": {
+    "kind": "original"
+  },
+  "precisions": {
+    "fp32": {
+      "num_warps": 4,
+      "waves_per_eu": 0,
+      "num_stages": 2
+    },
+    "bf16": {
+      "num_warps": 4,
+      "waves_per_eu": 0,
+      "num_stages": 2
+    },
+    "fp8": {
+      "num_warps": 4,
+      "waves_per_eu": 0,
+      "num_stages": 2
+    }
+  },
+  "description": "Original PZ backward block selector and launch metadata for every supported runtime shape and architecture."
+}

--- a/src/qkan/solver/flash/policies/pz-gfx942-n10000-batch1000-r3-fixed-preacts-fast-v1.json
+++ b/src/qkan/solver/flash/policies/pz-gfx942-n10000-batch1000-r3-fixed-preacts-fast-v1.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "name": "pz-gfx942-n10000-batch1000-r3-fixed-preacts-fast-v1",
+  "operation": "pz_backward",
+  "architecture": {
+    "kind": "exact",
+    "value": "gfx942"
+  },
+  "match": {
+    "kind": "exact",
+    "n_oi": 10000,
+    "batch": 1000,
+    "reps": 3,
+    "preacts_trainable": false,
+    "fast_measure": true
+  },
+  "block_selector": {
+    "kind": "fixed",
+    "block_b": 1024
+  },
+  "precisions": {
+    "fp32": {
+      "num_warps": 2,
+      "waves_per_eu": 1,
+      "num_stages": 2
+    },
+    "bf16": {
+      "num_warps": 4,
+      "waves_per_eu": 1,
+      "num_stages": 2
+    },
+    "fp8": {
+      "num_warps": 2,
+      "waves_per_eu": 1,
+      "num_stages": 2
+    }
+  },
+  "description": "PZ backward launch for the exact n_oi=10000, batch=1000 fixed-preacts fast-measure shape."
+}

--- a/src/qkan/solver/flash/policies/pz-gfx942-n256-batch4096-r3-fixed-preacts-fast-v1.json
+++ b/src/qkan/solver/flash/policies/pz-gfx942-n256-batch4096-r3-fixed-preacts-fast-v1.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "name": "pz-gfx942-n256-batch4096-r3-fixed-preacts-fast-v1",
+  "operation": "pz_backward",
+  "architecture": {
+    "kind": "exact",
+    "value": "gfx942"
+  },
+  "match": {
+    "kind": "exact",
+    "n_oi": 256,
+    "batch": 4096,
+    "reps": 3,
+    "preacts_trainable": false,
+    "fast_measure": true
+  },
+  "block_selector": {
+    "kind": "fixed",
+    "block_b": 512
+  },
+  "precisions": {
+    "fp32": {
+      "num_warps": 2,
+      "waves_per_eu": 1,
+      "num_stages": 2
+    },
+    "bf16": {
+      "num_warps": 2,
+      "waves_per_eu": 1,
+      "num_stages": 2
+    },
+    "fp8": {
+      "num_warps": 2,
+      "waves_per_eu": 1,
+      "num_stages": 2
+    }
+  },
+  "description": "PZ backward launch for the exact n_oi=256, batch=4096 fixed-preacts fast-measure shape."
+}

--- a/src/qkan/solver/flash/policies/pz-gfx942-n256-batch512-r3-fixed-preacts-fast-v1.json
+++ b/src/qkan/solver/flash/policies/pz-gfx942-n256-batch512-r3-fixed-preacts-fast-v1.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "name": "pz-gfx942-n256-batch512-r3-fixed-preacts-fast-v1",
+  "operation": "pz_backward",
+  "architecture": {
+    "kind": "exact",
+    "value": "gfx942"
+  },
+  "match": {
+    "kind": "exact",
+    "n_oi": 256,
+    "batch": 512,
+    "reps": 3,
+    "preacts_trainable": false,
+    "fast_measure": true
+  },
+  "block_selector": {
+    "kind": "fixed",
+    "block_b": 512
+  },
+  "precisions": {
+    "fp32": {
+      "num_warps": 1,
+      "waves_per_eu": 0,
+      "num_stages": 2
+    },
+    "bf16": {
+      "num_warps": 1,
+      "waves_per_eu": 3,
+      "num_stages": 2
+    },
+    "fp8": {
+      "num_warps": 2,
+      "waves_per_eu": 2,
+      "num_stages": 2
+    }
+  },
+  "description": "PZ backward launch for the exact n_oi=256, batch=512 fixed-preacts fast-measure shape."
+}


### PR DESCRIPTION
## Summary

This PR replaces the hardcoded large-PZ launch heuristic with an explicit, named **launch-policy** system for the PZ backward Triton kernel, and adds a newly tuned policy for the 16×16 / batch-512 shape.

The previous revision forced `BLOCK_B=1024` for any shape satisfying `n_oi >= 256 and batch >= 256`. That predicate is gone. Launch metadata now lives in validated JSON documents under `src/qkan/solver/flash/policies/`, loaded by `src/qkan/solver/flash/launch_policy.py` and named through a new `pz_launch_policy` solver option. Policies are **opt-in and fail closed**: omitting the option resolves `default.json`, which reproduces the original adaptive `_select_block_b` behaviour, and naming a policy whose architecture or shape does not match the runtime raises `LaunchPolicyMismatchError` rather than silently applying a mismatched tile.

The PR also fixes the P1 review finding: `waves_per_eu` is now gated behind a backend capability check so it can never reach a CUDA launch.

PZ forward, RPZ, and real solver paths are unchanged.

### Packaged policies

All exact-match policies additionally require `reps=3`, `preacts_trainable=false`, `fast_measure=true`.

| Policy | Architecture | Shape | `block_b` | `num_warps`/`waves_per_eu`/`num_stages` (fp32, bf16, fp8) |
| --- | --- | --- | --- | --- |
| `default` | any | any | adaptive `_select_block_b` | `4/0/2`, `4/0/2`, `4/0/2` |
| `pz-gfx942-n10000-batch1000-r3-fixed-preacts-fast-v1` | `gfx942` | `n_oi=10000`, `batch=1000` | 1024 | `2/1/2`, `4/1/2`, `2/1/2` |
| `pz-gfx942-n256-batch4096-r3-fixed-preacts-fast-v1` | `gfx942` | `n_oi=256`, `batch=4096` | 512 | `2/1/2`, `2/1/2`, `2/1/2` |
| `pz-gfx942-n256-batch512-r3-fixed-preacts-fast-v1` | `gfx942` | `n_oi=256`, `batch=512` | 512 | `1/0/2`, `1/3/2`, `2/2/2` |

The `n10000-batch1000` policy carries forward exactly the configuration the previous revision of this PR applied automatically to the B5 envelope. It is now selected by name instead of by threshold.

## Motivation

Profiling the B5 workload identified `_pz_encoding_backward_kernel` as the dominant solver kernel:

```text
forward:   0.347966 ms
backward: 25.865740 ms
hotspot:  _pz_encoding_backward_kernel
share:    98.67%
```

Raising `BLOCK_B` from 128 to 1024 is the right answer *for B5*, where batch 1000 already pads to 1024 and the 10,000-way grid saturates the device. It is the wrong answer for other shapes that happen to clear the same thresholds, which is what the `n_oi >= 256 and batch >= 256` predicate could not distinguish. Making the tuned envelope an explicitly named artifact, rather than an inferred one, is what this PR is for.

## Implementation

`triton_pz_backward` resolves one policy per call and derives every launch parameter from it:

```python
policy = select_pz_backward_policy(
    n_oi=out_dim * in_dim,
    batch=batch,
    architecture=architecture,
    precision=precision_kind,
    reps=reps,
    preacts_trainable=preacts_trainable,
    fast_measure=fast_measure,
    policy_name=policy_name,   # None -> "default"
)
BLOCK_B = policy.launch.block_b
launch_options = _launch_options(policy.launch)
```

`launch_policy.py` provides the loader and a strict validator: unknown keys, out-of-range values and non-power-of-two `num_warps` are rejected at load time, and the architecture field is not vendor-hardcoded (an `sm90` policy validates fine). Policies are read through `importlib.resources`, so `MANIFEST.in` and `pyproject.toml` were updated to ship the JSON as package data in wheels.

### `waves_per_eu` on non-HIP backends (P1 fix)

The previous revision passed `waves_per_eu=` unconditionally to the kernel launch. `waves_per_eu` is an AMD/HIP-only Triton launch option, and Triton's JIT rejects any launch keyword its backend does not declare — in Triton 3.7.1, `triton/runtime/jit.py`:

```python
if k not in options.__dict__ and k not in sigkeys:
    raise KeyError("Keyword argument %s was specified but unrecognised" % k)
```

So the keyword must never reach a CUDA launch. All policy launch options now funnel through one call site:

```python
@lru_cache(maxsize=None)
def _supports_waves_per_eu() -> bool:
    try:
        target = driver.active.get_current_target()
        options = make_backend(target).parse_options({})
    except Exception:
        return torch.version.hip is not None
    return "waves_per_eu" in options.__dict__


def _launch_options(launch: LaunchConfig) -> dict[str, int]:
    options = {"num_warps": launch.num_warps, "num_stages": launch.num_stages}
    if _supports_waves_per_eu():
        options["waves_per_eu"] = launch.waves_per_eu
    elif launch.waves_per_eu:
        _warn_waves_per_eu_dropped(launch.waves_per_eu)
    return options
```

The gate resolves the *active* Triton backend and applies the same `options.__dict__` membership test the JIT applies, rather than inferring the vendor from `torch.version`; `torch.version.hip` is only a last-resort fallback if driver introspection raises. Dropping `waves_per_eu=0` is silent because 0 is also the HIP default; dropping a non-zero value emits a one-time `RuntimeWarning`.

Confirmed against Triton 3.7.1's real options objects: `CUDAOptions` has no `waves_per_eu`, `HIPOptions` does.

> **Scope of the NVIDIA claim.** This makes the launch keyword safe on CUDA. It does **not** establish that PZ backward works on NVIDIA. No kernel has been compiled or run by Triton's CUDA backend as part of this work. The CUDA path is covered only by introspection of Triton's real `CUDAOptions` class and by mocking the driver — never on physical NVIDIA hardware. The kernel also uses `fp8e4nv` state tensors and `num_stages=2` pipelining whose cross-backend behaviour is untested. Anyone wanting NVIDIA support should treat that as unverified work still to do.

## Review findings addressed

**P1 — `waves_per_eu` passed unconditionally, breaking `solver="flash"` PZ backward on NVIDIA.** Fixed as above, with the caveat on NVIDIA support stated explicitly.

**P2 — 256-row batches padded to 1024, inflating the state allocation.** Fixed by removing the predicate. The `states` scratch tensor is sized `n_programs × n_states × 4 × BLOCK_B` with `n_programs = n_oi × ceil(batch / BLOCK_B)`, so at `batch=256` the padded row count is `1 × 1024` under the forced tile versus `2 × 128 = 256` under the adaptive selector — a 4× allocation, matching the reviewer's ~3 GiB → ~12 GiB figure. Shapes with no named policy now keep the adaptive tile, so this regression is structurally gone rather than re-tuned around. (At B5's `batch=1000` both paths pad to 1024 rows, which is why the original change did not surface it.)

**P2 — 256-pair grids underfill the device.** The reviewer is right, and our own tuning data agrees with them. At `n_oi=256` a single batch block yields 256 programs against the MI300X's 304 CUs (confirmed from `multi_processor_count`), and the aggressive 1024 tile is measurably the wrong choice for this shape: a sweep out to `block_b=4096` shows 512 is a genuine interior optimum, beating 1024 in all three precisions. The tuned `n256-batch512` policy lands on `block_b=512`, which puts the whole batch in one block with no padding waste. This finding directly motivated the shape-scoped policy design rather than a wider threshold.

## Benchmark environment

- GPU: AMD Instinct MI300X (`gfx942:sramecc+:xnack-`), 304 CUs
- ROCm: 7.14 (HIP 7.14.60850)
- PyTorch: 2.12.0
- Triton: 3.7.1
- Python: 3.14.4

Profiler timings were used only to identify bottlenecks. Acceptance decisions used unprofiled paired benchmarks.

## Performance

### New: 16×16 layer at batch 512 (`n_oi = out_dim × in_dim = 256`)

The `n256-batch512` policy was produced by an automated staged parameter sweep (105 measurements over `block_b` × `num_warps` × `waves_per_eu` × `num_stages`, plus a 93-measurement boundary sweep), with the isolated `triton_pz_backward` call as the objective.

**Isolated kernel** — median of 9 × 200 iterations, tuned policy against `default`:

| Precision | `default` (`block_b=128`, `4/0/2`) | Tuned (`block_b=512`) | Speedup |
| --- | --- | --- | --- |
| FP32 | 0.2810 ms | 0.0853 ms | **3.30×** |
| BF16 | 0.2690 ms | 0.0805 ms | **3.34×** |
| FP8 checkpoint | 0.2522 ms | 0.0868 ms | **2.91×** |

Sample standard deviation is ~0.0002 ms, so these separations are far outside noise.

**End-to-end training step** — 7 interleaved paired runs per arm (warmup 50, 300 iterations):

| Precision | `default` median | Tuned median | Speedup | 2σ noise floor | Significant? |
| --- | --- | --- | --- | --- | --- |
| FP32 | 0.5834 ms | 0.5749 ms | 1.015× | 0.0672 ms | **no** |
| BF16 | 0.6123 ms | 0.6301 ms | 0.972× | 0.0792 ms | **no** |
| FP8 checkpoint | 0.6125 ms | 0.6226 ms | 0.984× | 0.1037 ms | **no** |

**There is no end-to-end win at this shape, and this PR does not claim one.** The step is host-dispatch-bound: measured GPU work under the default policy is `0.068` (forward) + `0.281` (backward) = `0.349 ms` against a `0.583 ms` step, and `forward_ms` sits at `0.068 ms` for FP32, BF16 and FP8 alike despite 4× differences in data volume. Removing `0.196 ms` of kernel time moved the step by `0.000 ± 0.07 ms`. The remainder is autograd dispatch, gradient/scratch allocation and Python overhead. This was inferred from timing evidence only; it was not confirmed with a host-side dispatch trace.

The policy is worth shipping because the kernel-level improvement is real and will surface at larger batches or once the host cost comes down — but it should not be expected to change training throughput at `batch=512` today.

**Why `block_b` dominates.** Best FP32 median per tile at the joint `block_b` × `num_warps` stage, and the boundary sweep confirming 512 is interior rather than a search-edge artifact:

| `block_b` | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| FP32 median ms | 0.7316 | 0.3842 | 0.2165 | 0.1425 | 0.0860 | 0.0975 | 0.0991 | 0.1035 |

**Per-precision knobs, honestly.** `block_b=512` is the only strong effect. Of the per-precision values, only BF16's `waves_per_eu=3` (0.0805 ms vs 0.0812 ms at `waves_per_eu=0`, ~3σ) is a measured effect. FP32's `waves_per_eu` and FP8's `num_stages` both fell inside the tie set — candidates whose medians differ by less than two combined standard deviations — and were resolved by a noise-aware tie-break toward the more conventional value, with the tied candidates recorded for audit. They should not be read as tuned findings. `num_stages` measured within noise at every value from 1 to 4 for all three precisions.

### Regression check on the existing envelope

Re-running the tuned policy on MI300X after the refactor reproduces the recorded medians:

```text
isolated triton_pz_backward (median of 9 x 200 iterations)
  fp32 0.08575 ms  (baseline 0.08526 ms, +0.57%)  grad_delta=3.815e-06
  bf16 0.08112 ms  (baseline 0.08048 ms, +0.81%)  grad_delta=3.815e-06
  fp8  0.08690 ms  (baseline 0.08678 ms, +0.14%)  grad_delta=5.493e-04

waves_per_eu accepted by backend: True
no timing regression
```

The +0.14% to +0.81% deltas are comparable to run-to-run variation at this magnitude (per-sample σ is 0.0002–0.0005 ms) and are not a regression.

### Pre-existing B5 results (`n_oi=10000`, `batch=1000`, `in/out = 100 × 100`)

These were measured on the earlier revision of this PR and are **scoped to the B5 shape only**. They are unchanged by this refactor because `pz-gfx942-n10000-batch1000-r3-fixed-preacts-fast-v1` carries the identical launch configuration, but note that under the new design they apply only when that policy is named — the previous revision applied it automatically. They have not been re-measured on the refactored code.

Approximate cumulative speedup relative to the original B5 implementation: FP32 **4.901×**, BF16 **5.657×**, FP8 checkpoint **5.962×**.

The BF16-specific four-warp candidate produced an additional **8.28%** improvement over the previous accepted BF16 configuration:

```text
Kernel: _pz_encoding_backward_kernel

BF16 training (7 ABBA pairs):
  baseline median:  4.469254 ms
  candidate median: 4.108205 ms
  relative delta:  -8.2837%
  bootstrap 95% CI: [-8.8401%, -8.0866%]

FP32 training guard:
  baseline median:  5.201653 ms
  candidate median: 5.203778 ms
  relative delta:  +0.0744%
  bootstrap 95% CI: [-0.2114%, +0.0969%]

FP8 training guard:
  baseline median:  3.582492 ms
  candidate median: 3.579235 ms
  relative delta:  -0.1007%
  bootstrap 95% CI: [-0.3483%, +0.1647%]

Correctness:
  blocking evaluations: 18
  blocking failures:    0

Generated gfx942 resources:
  VGPR:                  110
  SGPR:                  81
  VGPR spills:           0
  SGPR spills:           0
  peak memory regression: 0
```

## Correctness

- Curated matrix on the tuned policy: **18/18 blocking evaluations passed, 0 failures**, across FP32, BF16 and FP8-checkpoint (3 precisions × 3 seeds × 2 gradient seeds). Worst FP32 `grad_theta` `max_abs` is 2.5e-10; worst FP8-checkpoint `grad_theta` `max_abs` is 0.040, inside the 0.05 FP8 tolerance.
- The benchmark's built-in FP32 gate against the `complex64` exact oracle passes for both the default and the tuned arm.
- Unit tests cover schema validation and rejection, `kind: any` vs exact matching, fail-closed mismatch, non-vendor-hardcoded architectures, and the `waves_per_eu` gate on both Triton's real HIP and CUDA options objects.

---

<!-- NOT PART OF THE PR BODY -->

## Draft replies to the Codex review comments

**Reply to P1 (`waves_per_eu` passed unconditionally):**

> Confirmed and fixed. `waves_per_eu` now goes through `_launch_options()`, which only includes it when `_supports_waves_per_eu()` is true. That helper resolves the active Triton backend and tests `"waves_per_eu" in options.__dict__` — the same membership check the JIT itself applies in `triton/runtime/jit.py` before raising `KeyError` — with `torch.version.hip` as a fallback only if driver introspection raises. Verified against Triton 3.7.1's real options classes: `CUDAOptions` has no `waves_per_eu`, `HIPOptions` does. Dropping a non-zero value emits a one-time `RuntimeWarning`; dropping 0 is silent since that is the HIP default anyway.
>
> To be explicit about scope: this makes the launch keyword safe on CUDA, but it does not make PZ backward *verified* on NVIDIA. No kernel has been compiled or run by Triton's CUDA backend here — the CUDA path is covered by introspection and mocking only, and the `fp8e4nv` state tensors and `num_stages` pipelining remain untested cross-backend. I've said so in the PR description rather than implying NVIDIA support.

**Reply to P2 (256-row batches padded to 1024):**

> Fixed by deleting the predicate rather than adjusting it. `states` is sized `n_programs × n_states × 4 × BLOCK_B` with `n_programs = n_oi × ceil(batch / BLOCK_B)`, so at `batch=256` the forced tile allocates `1 × 1024` padded rows against the adaptive selector's `2 × 128 = 256` — the 4× you identified. Launch metadata now comes from named, architecture-scoped, exact-match policies, and anything that does not match a named policy keeps the original adaptive `_select_block_b` tile. Naming a policy whose shape does not match the runtime raises `LaunchPolicyMismatchError` instead of applying it, so the tuned tile cannot leak onto shapes it was not measured on.

**Reply to P2 (256-pair grids underfilled):**

> You were right, and our tuning data backs you up. At `n_oi=256` a single batch block is 256 programs against the MI300X's 304 CUs, and the 1024 tile is measurably the wrong choice there. I ran an automated sweep on that exact shape at `batch=512`: `block_b=512` wins, and a boundary sweep out to 4096 confirms it is a genuine interior optimum rather than a search-edge artifact (FP32 medians 0.0860 / 0.0975 / 0.0991 / 0.1035 ms at 512 / 1024 / 2048 / 4096). That is now shipped as its own policy, and it cuts isolated `pz_backward` time 2.9–3.3× versus the default selector at this shape.
>
> One caveat I want to be upfront about: the isolated-kernel win does not translate into an end-to-end training step win at `batch=512`. Across 7 interleaved paired runs all three precisions landed inside the noise floor, because the step is host-dispatch-bound (~0.35 ms of GPU work against a ~0.58 ms step). The policy is worth shipping for the kernel-level improvement, but I am not claiming a throughput change at this shape.
